### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 script.service.hyperion
 =======================
 
-Kodi addon to capture video data and send it to Hyperion. Note that this plugin will not work for Kodi running on the Raspberry Pi, because the video capture interface is not (yet?) supported on this device.
+Kodi addon to capture video data and send it to Hyperion.
 
 Information about Hyperion can be found here: https://wiki.hyperion-project.org
 


### PR DESCRIPTION
The raspi actually does support the addon.

I tried with raspbian jessie ad streamed the led data to its local hyperion (as this works better than the frame grabber).

Also I was unable to find this addon in the wiki. I do not know why, but this addon should be menioned in the installation section.
