### PR TITLE
Misc improvements to delays and priority clearing

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -34,6 +34,7 @@ sys.path.append(xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')))
 		
 from settings import Settings
 from state import DisconnectedState
+from hyperion.Hyperion import Hyperion
 
 if  __name__ == "__main__":
 	# read settings

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -54,6 +54,42 @@ msgctxt "#32010"
 msgid "Frame rate (fps)"
 msgstr ""
 
+msgctxt "#33001"
+msgid "Delays"
+msgstr ""
+
+msgctxt "#33002"
+msgid "Delay default (ms)"
+msgstr ""
+
+msgctxt "#33003"
+msgid "Delay 23/24FPS (ms)"
+msgstr ""
+
+msgctxt "#33004"
+msgid "Delay 25FPS (ms)"
+msgstr ""
+
+msgctxt "#33005"
+msgid "Delay 50FPS (ms)"
+msgstr ""
+
+msgctxt "#33006"
+msgid "Delay 59FPS (ms)"
+msgstr ""
+
+msgctxt "#33007"
+msgid "Delay 60FPS (ms)"
+msgstr ""
+
+msgctxt "#33100"
+msgid "Default delay is only used if below FPS isn't matched"
+msgstr ""
+
+msgctxt "#33200"
+msgid "Always use default delay"
+msgstr ""
+
 msgctxt "#32100"
 msgid "Error: Unable to connect to Hyperion. Wrong IP-address?"
 msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -54,6 +54,42 @@ msgctxt "#32010"
 msgid "Frame rate (fps)"
 msgstr "Bildfrequenz (fps)"
 
+msgctxt "#33001"
+msgid "Verzögerungen"
+msgstr ""
+
+msgctxt "#33002"
+msgid "Verzögerung Standard (ms)"
+msgstr "Wird nur verwendet wenn FPS kein Match ist"
+
+msgctxt "#33003"
+msgid "Verzögerung für 23/24FPS (ms)"
+msgstr ""
+
+msgctxt "#33004"
+msgid "Verzögerung für 25FPS (ms)"
+msgstr ""
+
+msgctxt "#33005"
+msgid "Verzögerung für 50FPS (ms)"
+msgstr ""
+
+msgctxt "#33006"
+msgid "Verzögerung für 59FPS (ms)"
+msgstr ""
+
+msgctxt "#33007"
+msgid "Verzögerung für 60FPS (ms)"
+msgstr ""
+
+msgctxt "#33100"
+msgid "Die Standardverzögerung wird nur verwendet, wenn unter FPS nicht übereinstimmt"
+msgstr ""
+
+msgctxt "#33200"
+msgid "Verwenden Sie immer die Standardverzögerung"
+msgstr ""
+
 msgctxt "#32100"
 msgid "Error: Unable to connect to Hyperion. Wrong IP-address?"
 msgstr "Fehler: Kann keine Verbindung zu Hyperion aufbauen. Falsche IP-Adresse?"

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -82,10 +82,7 @@ class Settings:
 		self.capture_height = int(addon.getSetting("capture_height"))
 
 		# Hack around Kodi's settings readout limitations
-		useDefaultDelay = False;
-		if addon.getSetting("use_default_delay") == 'true':
-			useDefaultDelay = True
-		self.useDefaultDelay = useDefaultDelay
+		self.useDefaultDelay = addon.getSetting('use_default_delay').lower() == 'true'
 
 		self.delay = int(addon.getSetting("delay"))
 		self.delay24 = int(addon.getSetting("delay24"))

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -80,7 +80,19 @@ class Settings:
 		self.timeout = int(addon.getSetting("reconnect_timeout"))
 		self.capture_width = int(addon.getSetting("capture_width"))
 		self.capture_height = int(addon.getSetting("capture_height"))
-		self.framerate = int(addon.getSetting("framerate"))
+
+		# Hack around Kodi's settings readout limitations
+		useDefaultDelay = False;
+		if addon.getSetting("use_default_delay") == 'true':
+			useDefaultDelay = True
+		self.useDefaultDelay = useDefaultDelay
+
+		self.delay = int(addon.getSetting("delay"))
+		self.delay24 = int(addon.getSetting("delay24"))
+		self.delay25 = int(addon.getSetting("delay25"))
+		self.delay50 = int(addon.getSetting("delay50"))
+		self.delay59 = int(addon.getSetting("delay59"))
+		self.delay60 = int(addon.getSetting("delay60"))
 
 		self.showErrorMessage = True
 		self.rev += 1

--- a/resources/lib/state.py
+++ b/resources/lib/state.py
@@ -85,11 +85,7 @@ class ConnectedState:
         # try to connect to hyperion
         self.__hyperion = Hyperion(self.__settings.address, self.__settings.port)
 
-        # Force clearing of priority (mainly for Orbs)
-        xbmc.sleep(1000)
-        self.__hyperion.clear(self.__settings.priority)
-        xbmc.sleep(1000)
-        self.__hyperion.clear(self.__settings.priority)
+        self.clear_priority()
 
         # create the capture object
         self.__capture = xbmc.RenderCapture()
@@ -104,17 +100,20 @@ class ConnectedState:
         del self.__data
         del self.__useLegacyApi
 
+    def clear_priority(self):
+        # Force clearing of priority (mainly for forwarded instances)
+        xbmc.sleep(1000)
+        self.__hyperion.clear(self.__settings.priority)
+        xbmc.sleep(1000)
+        self.__hyperion.clear(self.__settings.priority)
+
     def execute(self):
         '''Execute the state
           - return: The new state to execute
         '''
         # check if we still need to grab
         if not self.__settings.grabbing():
-            # Force clearing of priority (mainly for Orbs)
-            xbmc.sleep(1000)
-            self.__hyperion.clear(self.__settings.priority)
-            xbmc.sleep(1000)
-            self.__hyperion.clear(self.__settings.priority)
+            self.clear_priority()
 
             # return to the disconnected state
             return DisconnectedState(self.__settings)
@@ -157,11 +156,7 @@ class ConnectedState:
                 notify(xbmcaddon.Addon().getLocalizedString(32101))
                 return ErrorState(self.__settings)
         else:
-            # Force clearing of priority (mainly for Orbs)
-            xbmc.sleep(1000)
-            self.__hyperion.clear(self.__settings.priority)
-            xbmc.sleep(1000)
-            self.__hyperion.clear(self.__settings.priority)
+            self.clear_priority()
 
         if self.__useLegacyApi:
             if self.__captureState != xbmc.CAPTURE_STATE_WORKING:

--- a/resources/lib/state.py
+++ b/resources/lib/state.py
@@ -30,193 +30,195 @@ from misc import log
 from misc import notify
 
 class DisconnectedState:
-  '''
-  Default state class when disconnected from the Hyperion server
-  '''
-
-  def __init__(self, settings):
-    '''Constructor
-      - settings: Settings structure
     '''
-    log("Entering disconnected state")
-    self.__settings = settings
-
-  def execute(self):
-    '''Execute the state
-      - return: The new state to execute
+    Default state class when disconnected from the Hyperion server
     '''
-    # check if we are enabled
-    if not self.__settings.grabbing():
-      xbmc.sleep(500)
-      return self
 
-    # we are enabled and want to advance to the connected state
-    try:
-      nextState = ConnectedState(self.__settings)
-      return nextState
-    except Exception, e:
-      # unable to connect. notify and go to the error state
-      if self.__settings.showErrorMessage:
-        notify(xbmcaddon.Addon().getLocalizedString(32100))
-        self.__settings.showErrorMessage = False
+    def __init__(self, settings):
+        '''Constructor
+          - settings: Settings structure
+        '''
+        log("Entering disconnected state")
+        self.__settings = settings
 
-      # continue in the error state
-      return ErrorState(self.__settings)
+    def execute(self):
+        '''Execute the state
+          - return: The new state to execute
+        '''
+        # check if we are enabled
+        if not self.__settings.grabbing():
+            xbmc.sleep(500)
+            return self
+
+        # we are enabled and want to advance to the connected state
+        try:
+            nextState = ConnectedState(self.__settings)
+            return nextState
+        except Exception, e:
+            # unable to connect. notify and go to the error state
+            if self.__settings.showErrorMessage:
+                notify(xbmcaddon.Addon().getLocalizedString(32100))
+                self.__settings.showErrorMessage = False
+
+            # continue in the error state
+            return ErrorState(self.__settings)
+
 
 class ConnectedState:
-  '''
-  State class when connected to Hyperion and grabbing video
-  '''
-
-  def __init__(self, settings):
-    '''Constructor
-      - settings: Settings structure
     '''
-    log("Entering connected state")
-
-    self.__settings = settings
-    self.__hyperion = None
-    self.__capture = None
-    self.__captureState = None
-    self.__data = None
-    self.__useLegacyApi = True
-
-    # try to connect to hyperion
-    self.__hyperion = Hyperion(self.__settings.address, self.__settings.port)
-
-    # Force clearing of priority (mainly for Orbs)
-    xbmc.sleep(1000)
-    self.__hyperion.clear(self.__settings.priority)
-    xbmc.sleep(1000)
-    self.__hyperion.clear(self.__settings.priority)
-
-    # create the capture object
-    self.__capture = xbmc.RenderCapture()
-    self.__capture.capture(self.__settings.capture_width, self.__settings.capture_height)
-
-  def __del__(self):
-    '''Destructor
+    State class when connected to Hyperion and grabbing video
     '''
-    del self.__hyperion
-    del self.__capture
-    del self.__captureState
-    del self.__data
-    del self.__useLegacyApi
 
-  def execute(self):
-    '''Execute the state
-      - return: The new state to execute
-    '''
-    # check if we still need to grab
-    if not self.__settings.grabbing():
-      # Force clearing of priority (mainly for Orbs)
-      xbmc.sleep(1000)
-      self.__hyperion.clear(self.__settings.priority)
-      xbmc.sleep(1000)
-      self.__hyperion.clear(self.__settings.priority)
+    def __init__(self, settings):
+        '''Constructor
+          - settings: Settings structure
+        '''
+        log("Entering connected state")
 
-      # return to the disconnected state
-      return DisconnectedState(self.__settings)
+        self.__settings = settings
+        self.__hyperion = None
+        self.__capture = None
+        self.__captureState = None
+        self.__data = None
+        self.__useLegacyApi = True
 
-    # check the xbmc API Version
-    try:
-      self.__capture.getCaptureState()
-    except:
-      self.__useLegacyApi = False
+        # try to connect to hyperion
+        self.__hyperion = Hyperion(self.__settings.address, self.__settings.port)
 
-    # capture an image
-    startReadOut = False
-    if self.__useLegacyApi:
-      self.__capture.waitForCaptureStateChangeEvent(200)
-      self.__captureState = self.__capture.getCaptureState()
-      if self.__captureState == xbmc.CAPTURE_STATE_DONE:
-        startReadOut = True
-    else:
-      self.__data = self.__capture.getImage()
-      if len(self.__data) > 0:
-        startReadOut = True
+        # Force clearing of priority (mainly for Orbs)
+        xbmc.sleep(1000)
+        self.__hyperion.clear(self.__settings.priority)
+        xbmc.sleep(1000)
+        self.__hyperion.clear(self.__settings.priority)
 
-    if startReadOut:
-      if self.__useLegacyApi:
-        self.__data = self.__capture.getImage()
-
-      # retrieve image data and reformat into rgb format
-      if self.__capture.getImageFormat() == 'ARGB':
-        del self.__data[0::4]
-      elif self.__capture.getImageFormat() == 'BGRA':
-        del self.__data[3::4]
-        self.__data[0::3], self.__data[2::3] = self.__data[2::3], self.__data[0::3]
-
-      try:
-        # send image to hyperion
-        self.__hyperion.sendImage(self.__capture.getWidth(), self.__capture.getHeight(), str(self.__data),
-                                  self.__settings.priority, -1)
-      except Exception, e:
-        # unable to send image. notify and go to the error state
-        notify(xbmcaddon.Addon().getLocalizedString(32101))
-        return ErrorState(self.__settings)
-    else:
-      # Force clearing of priority (mainly for Orbs)
-      xbmc.sleep(1000)
-      self.__hyperion.clear(self.__settings.priority)
-      xbmc.sleep(1000)
-      self.__hyperion.clear(self.__settings.priority)
-
-    if self.__useLegacyApi:
-      if self.__captureState != xbmc.CAPTURE_STATE_WORKING:
-        # the current capture is processed or it has failed, we request a new one
+        # create the capture object
+        self.__capture = xbmc.RenderCapture()
         self.__capture.capture(self.__settings.capture_width, self.__settings.capture_height)
 
-    # Sleep if any delay is configured
-    sleeptime = self.__settings.delay
+    def __del__(self):
+        '''Destructor
+        '''
+        del self.__hyperion
+        del self.__capture
+        del self.__captureState
+        del self.__data
+        del self.__useLegacyApi
 
-    if self.__settings.useDefaultDelay == False:
-      try:
-        videofps = math.ceil(float(xbmc.getInfoLabel('Player.Process(VideoFPS)')))
-        if videofps == 24:
-          sleeptime = self.__settings.delay24
-        if videofps == 25:
-          sleeptime = self.__settings.delay25
-        if videofps == 50:
-          sleeptime = self.__settings.delay50
-        if videofps == 59:
-          sleeptime = self.__settings.delay59
-        if videofps == 60:
-          sleeptime = self.__settings.delay60
-      except ValueError:
-        pass
+    def execute(self):
+        '''Execute the state
+          - return: The new state to execute
+        '''
+        # check if we still need to grab
+        if not self.__settings.grabbing():
+            # Force clearing of priority (mainly for Orbs)
+            xbmc.sleep(1000)
+            self.__hyperion.clear(self.__settings.priority)
+            xbmc.sleep(1000)
+            self.__hyperion.clear(self.__settings.priority)
 
-    #log('Sleeping for (ms): %d :: %.3f' % (sleeptime, videofps))
-    xbmc.sleep(sleeptime)
-    return self
+            # return to the disconnected state
+            return DisconnectedState(self.__settings)
+
+        # check the xbmc API Version
+        try:
+            self.__capture.getCaptureState()
+        except:
+            self.__useLegacyApi = False
+
+        # capture an image
+        startReadOut = False
+        if self.__useLegacyApi:
+            self.__capture.waitForCaptureStateChangeEvent(200)
+            self.__captureState = self.__capture.getCaptureState()
+            if self.__captureState == xbmc.CAPTURE_STATE_DONE:
+                startReadOut = True
+        else:
+            self.__data = self.__capture.getImage()
+            if len(self.__data) > 0:
+                startReadOut = True
+
+        if startReadOut:
+            if self.__useLegacyApi:
+                self.__data = self.__capture.getImage()
+
+            # retrieve image data and reformat into rgb format
+            if self.__capture.getImageFormat() == 'ARGB':
+                del self.__data[0::4]
+            elif self.__capture.getImageFormat() == 'BGRA':
+                del self.__data[3::4]
+                self.__data[0::3], self.__data[2::3] = self.__data[2::3], self.__data[0::3]
+
+            try:
+                # send image to hyperion
+                self.__hyperion.sendImage(self.__capture.getWidth(), self.__capture.getHeight(), str(self.__data),
+                                          self.__settings.priority, -1)
+            except Exception, e:
+                # unable to send image. notify and go to the error state
+                notify(xbmcaddon.Addon().getLocalizedString(32101))
+                return ErrorState(self.__settings)
+        else:
+            # Force clearing of priority (mainly for Orbs)
+            xbmc.sleep(1000)
+            self.__hyperion.clear(self.__settings.priority)
+            xbmc.sleep(1000)
+            self.__hyperion.clear(self.__settings.priority)
+
+        if self.__useLegacyApi:
+            if self.__captureState != xbmc.CAPTURE_STATE_WORKING:
+                # the current capture is processed or it has failed, we request a new one
+                self.__capture.capture(self.__settings.capture_width, self.__settings.capture_height)
+
+        # Sleep if any delay is configured
+        sleeptime = self.__settings.delay
+
+        if self.__settings.useDefaultDelay == False:
+            try:
+                videofps = math.ceil(float(xbmc.getInfoLabel('Player.Process(VideoFPS)')))
+                if videofps == 24:
+                    sleeptime = self.__settings.delay24
+                if videofps == 25:
+                    sleeptime = self.__settings.delay25
+                if videofps == 50:
+                    sleeptime = self.__settings.delay50
+                if videofps == 59:
+                    sleeptime = self.__settings.delay59
+                if videofps == 60:
+                    sleeptime = self.__settings.delay60
+            except ValueError:
+                pass
+
+        # log('Sleeping for (ms): %d :: %.3f' % (sleeptime, videofps))
+        xbmc.sleep(sleeptime)
+        return self
+
 
 class ErrorState:
-  '''
-  State class which is activated upon an error
-  '''
-
-  def __init__(self, settings):
-    '''Constructor
-      - settings: Settings structure
     '''
-    log("Entering error state")
-    self.__settings = settings
-
-  def execute(self):
-    '''Execute the state
-      - return: The new state to execute
+    State class which is activated upon an error
     '''
-    # take note of the current revision of the settings
-    rev = self.__settings.rev
 
-    # stay in error state for the specified timeout or until the settings have been changed
-    i = 0
-    while (i < self.__settings.timeout) and (rev == self.__settings.rev):
-      if self.__settings.abort:
-        return self
-      else:
-        xbmc.sleep(1000)
-      i += 1
+    def __init__(self, settings):
+        '''Constructor
+          - settings: Settings structure
+        '''
+        log("Entering error state")
+        self.__settings = settings
 
-    # continue in the disconnected state
-    return DisconnectedState(self.__settings)
+    def execute(self):
+        '''Execute the state
+          - return: The new state to execute
+        '''
+        # take note of the current revision of the settings
+        rev = self.__settings.rev
+
+        # stay in error state for the specified timeout or until the settings have been changed
+        i = 0
+        while (i < self.__settings.timeout) and (rev == self.__settings.rev):
+            if self.__settings.abort:
+                return self
+            else:
+                xbmc.sleep(1000)
+            i += 1
+
+        # continue in the disconnected state
+        return DisconnectedState(self.__settings)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -11,6 +11,16 @@
 		<setting label="32102" type="lsep"/>
 		<setting id="capture_width" type="number" label="32008" default="64" />
 		<setting id="capture_height" type="number" label="32009" default="64" />
-		<setting id="framerate" type="number" label="32010" default="10" />
+	</category>
+	<category label="33001">
+		<setting id="use_default_delay" type="bool" label="33200" default="true" />
+		<setting id="delay" type="number" label="33002" default="0" />
+		 <setting type="sep"/>
+		<setting label="33100" type="lsep"/>
+		<setting id="delay24" type="number" label="33003" default="0" />
+		<setting id="delay25" type="number" label="33004" default="0" />
+		<setting id="delay50" type="number" label="33005" default="0" />
+		<setting id="delay59" type="number" label="33006" default="0" />
+		<setting id="delay60" type="number" label="33007" default="0" />
 	</category>
 </settings>


### PR DESCRIPTION
- Added global or per FPS delays.
- Removed framerate option as it didn't make sense to keep with the new delay setup.
- Added Hyperion clear on disconnect / no image, this prevents stale images when forwarding to other Hyperion instances.